### PR TITLE
Fix build flag for version variable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-      - "-s -w -X github.com/lunarway/strong-duckling/cmd.version={{.Version}}"
+      - "-s -w -X main.version={{.Version}}"
 
 archive:
   format: binary


### PR DESCRIPTION
The current ldflags does not correctly set the version global in package main.