### PR TITLE
Run Go tests in all packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 script: |
   echo "Build strong-duckling" &&
   go build &&
-  go test
+  go test ./...
 
 services:
   - docker

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -2,4 +2,4 @@ package metrics
 
 import "github.com/lunarway/strong-duckling/internal/tcpchecker"
 
-var _ tcpchecker.Reporter = &PrometheusReporter{}
+var _ tcpchecker.Reporter = (&PrometheusReporter{}).TcpChecker()

--- a/internal/whooping/whooping.go
+++ b/internal/whooping/whooping.go
@@ -25,7 +25,7 @@ func (whooper *Whooper) RegisterListener(serveMux *http.ServeMux, listeningAddre
 		err := json.NewDecoder(r.Body).Decode(&whoop)
 
 		if err != nil {
-			log.Debugf("Got error trying to parse whoop", err)
+			log.Debugf("Got error trying to parse whoop: %+v", err)
 			http.Error(w, "can't read body", http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
The current Travis script does not run any tests.

This change sets the script to run all packages from the root.