### PR TITLE
Use time.Since instead of time.Now().Sub()

### DIFF
--- a/internal/tcpchecker/logreporter.go
+++ b/internal/tcpchecker/logreporter.go
@@ -33,7 +33,7 @@ func (r *logReporter) ReportPortCheck(report Report) {
 			Infof("TCP connection to %s opened", report.Name)
 	case !report.Open && !r.lastOpen:
 		// Port still closed
-		if time.Now().Sub(r.lastReport) > 5*time.Minute {
+		if time.Since(r.lastReport) > 5*time.Minute {
 			r.lastReport = time.Now()
 			r.lastOpen = report.Open
 			r.Logger.

--- a/internal/whooping/whooping.go
+++ b/internal/whooping/whooping.go
@@ -85,7 +85,7 @@ func (whooper *Whooper) Whoop(endpoint string, listeningEndpoint string) {
 
 		if whoop.Message == "whoop whoop" {
 			whooper.open = true
-			whooper.latency = time.Now().Sub(now)
+			whooper.latency = time.Since(now)
 			whooper.drift = now.Add(whooper.latency / 2).Sub(whoop.Timestamp)
 			log.Debugf("Got whoop whoop from %s. RemoteStatus is open is: %v and latency: %v and drift is %s",
 				fullEndpoint, whoop.RemoteStatus.Open, whoop.RemoteStatus.Latency, whoop.RemoteStatus.Drift)


### PR DESCRIPTION
This simplifies usage of relative time comparisons along with getting some
optimizations  implemented in time.Since.

Reported by [`staticcheck ./...`](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck)