### PR TITLE
Add checked_total metric to tcp checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ The application exposes Prometheus metrics on `/metrics` for general insight int
 
 Enable TCP checker metrics by setting `--tcp-checker` to continually try to establish TCP connections to a remote and report the results in logs and metrics.
 
-| Name                                             | Type    | Description                                     |
-| ------------------------------------------------ | ------- | ----------------------------------------------- |
-| `strong_duckling_tcp_checker_checked_total`      | Counter | Total number of checks performed on the address |
-| `strong_duckling_tcp_checker_connected_total`    | Counter | Total number of changes to connected state      |
-| `strong_duckling_tcp_checker_disconnected_total` | Counter | Total number of changes to disconnected state   |
-| `strong_duckling_tcp_checker_open_info`          | Gauge   | Connection is open if value 1 otherwise 0       |
+| Name                                             | Type    | Labels                                     | Description                                     |
+| ------------------------------------------------ | ------- | ------------------------------------------ | ----------------------------------------------- |
+| `strong_duckling_tcp_checker_checked_total`      | Counter | `address`, `port`, `name` (if set), `open` | Total number of checks performed on the address |
+| `strong_duckling_tcp_checker_connected_total`    | Counter | `address`, `port`, `name` (if set)         | Total number of changes to connected state      |
+| `strong_duckling_tcp_checker_disconnected_total` | Counter | `address`, `port`, `name` (if set)         | Total number of changes to disconnected state   |
+| `strong_duckling_tcp_checker_open_info`          | Gauge   | `address`, `port`, `name` (if set)         | Connection is open if value 1 otherwise 0       |
 
-All metrics contains the labels based on the configured `address`, `port` and optionally `name`.
+Here follows an example of a TCP check against a named endpoint `partner1` on IP `1.2.3.4` and port `4500`.
 
 ```
 # strong-duckling --listen=:9100 --tcp-checker partner1:1.2.3.4:4500

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ The application exposes Prometheus metrics on `/metrics` for general insight int
 | ---------------------- | ------------------------------ | --------------------------------------------------------- |
 | `strong_duckling_info` | `version`,`strongswan_version` | Metadata such as version info of the application it self. |
 
+## TCP checker
+
+Enable TCP checker metrics by setting `--tcp-checker` to continually try to establish TCP connections to a remote and report the results in logs and metrics.
+
+| Name                                             | Type    | Description                                     |
+| ------------------------------------------------ | ------- | ----------------------------------------------- |
+| `strong_duckling_tcp_checker_checked_total`      | Counter | Total number of checks performed on the address |
+| `strong_duckling_tcp_checker_connected_total`    | Counter | Total number of changes to connected state      |
+| `strong_duckling_tcp_checker_disconnected_total` | Counter | Total number of changes to disconnected state   |
+| `strong_duckling_tcp_checker_open_info`          | Gauge   | Connection is open if value 1 otherwise 0       |
+
+All metrics contains the labels based on the configured `address`, `port` and optionally `name`.
+
+```
+# strong-duckling --listen=:9100 --tcp-checker partner1:1.2.3.4:4500
+
+strong_duckling_tcp_checker_open_info{name="partner1", address="1.2.3.4", port="4500"} 1
+```
+
 ## IKE SA metrics
 
 Enable Strongswan metrics by setting `--vici-socket` to a charon socket of a running strongswan process.
@@ -36,6 +55,7 @@ Usually this is `/var/run/charon.vici`.
 | `strong_duckling_ike_sa_child_state_info`                     | Gauge     |        | Metadata on the state of the child SA    |
 
 ## Local development setup
+
 To use the test setup start a linux build watcher (requires nodemon) like this:
 
 ```bash
@@ -50,8 +70,8 @@ docker-compose up -d
 
 This will start 2 linked docker containers each running:
 
-* StrongSwan VPN
-* A small nodejs HTTP server on :8080
-* strong-duckling
+- StrongSwan VPN
+- A small nodejs HTTP server on :8080
+- strong-duckling
 
 The setup is configured to automatically connect the 2 containers using StrongSwan through an IKE v2 tunnel. The machines have added internal IPs `10.101.0.1` and `10.102.0.1`.


### PR DESCRIPTION
Adds a counter tracking when the tcp-checker runs.
It also fixes a bug in the `open_info` metric where it was never set to 0 if the
connection was no longer open.