### PR TITLE
Fix stuck command termination

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,6 @@ func main() {
 		go func() {
 			defer shutdownWg.Done()
 			tcpCheckerDaemon.Loop(shutdown)
-			componentDone <- nil
 		}()
 	}
 
@@ -160,7 +159,6 @@ func main() {
 		go func() {
 			d.Loop(shutdown)
 			log.Infof("vici strongswan checker daemon stopped. Terminating...")
-			componentDone <- nil
 		}()
 	}
 

--- a/main.go
+++ b/main.go
@@ -156,7 +156,9 @@ func main() {
 			},
 		})
 
+		shutdownWg.Add(1)
 		go func() {
+			defer shutdownWg.Done()
 			d.Loop(shutdown)
 			log.Infof("vici strongswan checker daemon stopped. Terminating...")
 		}()


### PR DESCRIPTION
If a signal stops the application it gets stuck when daemon go routines tried to
signal component ending.
This is not the intended behaviour and is fixed with this change.

Only signals and an error on the HTTP listeners are able to initiate a shutdown.
As the daemons have no reliable way of indicating that they've stopped, there is
no need for this mechanism.

Closes #15 