### PR TITLE
Add tcp-checker checked_total metric to registry

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -251,6 +251,7 @@ func NewPrometheusReporter(reg prometheus.Registerer, logger Logger) (*Prometheu
 		r.tcpChecker.open,
 		r.tcpChecker.connectedTotal,
 		r.tcpChecker.disconectedTotal,
+		r.tcpChecker.checks,
 		r.ikeSA.establishedSeconds,
 		r.ikeSA.packetsIn,
 		r.ikeSA.packetsOut,


### PR DESCRIPTION
The metric is not exposed as it is not registered on the Prometheus registry. It
should be, so this change adds it the the register call.