### PR TITLE
Detect and handle vici client connection errors

### DIFF
--- a/internal/vici/clientConn_test.go
+++ b/internal/vici/clientConn_test.go
@@ -1,0 +1,98 @@
+package vici
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientConn_Close_listen tests that Listen returns when Close is called.
+func TestClientConn_Close_listen(t *testing.T) {
+	conn, _ := net.Pipe()
+	defer conn.Close()
+
+	client := NewClientConn(conn)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	// wg will never be released if Listen does not terminated leading to a test
+	// timeout.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := client.Listen()
+		t.Logf("Listen err: %v", err)
+	}()
+
+	err := client.Close()
+	require.NoError(t, err, "expected a Listen error")
+}
+
+// TestClientConn_Listen_connClosed tests that Listen returns an error if the
+// net.Conn is closed on.
+func TestClientConn_Listen_connClosed(t *testing.T) {
+	// create a net.Conn that is closed right away to simulate a failed network
+	// connection.
+	conn, _ := net.Pipe()
+	conn.Close()
+
+	client := NewClientConn(conn)
+	defer client.Close()
+
+	err := client.Listen()
+
+	t.Logf("Err: %v", err)
+
+	require.Error(t, err, "expected a Listen error")
+
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("Error expected to be io.ErrClosedPipe but was: %v", err)
+	}
+}
+
+// TestClientConn_Listen_unhandleableSegmentType tests that Listen returns an
+// error if un unprocessable segment type is received.
+func TestClientConn_Listen_unprocessableSegmentType(t *testing.T) {
+	viciConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	// write EVENT_UNKNOWN response from vici daemon to fake un unprocessable
+	// payload
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer viciConn.Close()
+
+		message := []byte{
+			0x0, 0x0, 0x0, 0x1, // length 1 (single byte)
+			byte(stEVENT_UNKNOWN), // unprocessable but valid segment type
+		}
+		_, err := viciConn.Write(message)
+		if err != nil {
+			t.Logf("Failed to write vici message: %v", err)
+			return
+		}
+		t.Logf("Wrote message to vici conn: %v", message)
+	}()
+
+	client := NewClientConn(clientConn)
+	defer client.Close()
+
+	err := client.Listen()
+
+	t.Logf("Listen err: %v", err)
+
+	require.Error(t, err, "Listen() didn't return error")
+
+	if errors.Is(err, io.EOF) {
+		t.Fatalf("Listen() returned io.EOF: this happens on net.Conn.Close() so the listener did not stop in time")
+	}
+}

--- a/internal/vici/msg.go
+++ b/internal/vici/msg.go
@@ -22,6 +22,29 @@ const (
 	stEVENT            segmentType = 7
 )
 
+func (s segmentType) String() string {
+	switch s {
+	case stCMD_REQUEST:
+		return "CMD_REQUEST"
+	case stCMD_RESPONSE:
+		return "CMD_RESPONSE"
+	case stCMD_UNKNOWN:
+		return "CMD_UNKNOWN"
+	case stEVENT_REGISTER:
+		return "EVENT_REGISTER"
+	case stEVENT_UNREGISTER:
+		return "EVENT_UNREGISTER"
+	case stEVENT_CONFIRM:
+		return "EVENT_CONFIRM"
+	case stEVENT_UNKNOWN:
+		return "EVENT_UNKNOWN"
+	case stEVENT:
+		return "EVENT"
+	default:
+		return fmt.Sprintf("unknown segment type: %d", s)
+	}
+}
+
 func (t segmentType) hasName() bool {
 	switch t {
 	case stCMD_REQUEST, stEVENT_REGISTER, stEVENT_UNREGISTER, stEVENT:


### PR DESCRIPTION
Currently ClientConn starts a go routine on construction that runs the data read
loop. Errors from this read loop is reported on ClientConn.lastError but as any
request on the client uses ClientConn.readResponse to receive data and that
function will timeout if the underlying connection has issues the
ClientConn.lastError is overwritten with a timeout error. This results in an
invisible and non-recoverable error state of the client.

This change moves the read loop into an exported Listen method that clients are
required to call to start the clients read loop. This bringes clients in control
of the error handling and avoids the subtle bug on error reporting through
ClientConn.lastError.

The main function is updated accordingly to start the client listeners in Go
routines and handle shutdown appropriately.

For better error reporting a String method is added to segmentType so logs will
write the human readable name of the segment instead of the integer based byte
value.