### PR TITLE
Close on already registered vici errors

### DIFF
--- a/internal/vici/initiate.go
+++ b/internal/vici/initiate.go
@@ -15,6 +15,13 @@ func (c *ClientConn) Initiate(child string, ike string, logger func(fields map[s
 		request["ike"] = ike
 	}
 
+	err = c.RegisterEvent("control-log", func(response map[string]interface{}) {
+		logger(response)
+	})
+	if err != nil {
+		return fmt.Errorf("error registering control-log event: %w", err)
+	}
+
 	defer func() {
 		unregisterErr := c.UnregisterEvent("control-log")
 		if unregisterErr != nil {
@@ -25,13 +32,6 @@ func (c *ClientConn) Initiate(child string, ike string, logger func(fields map[s
 			err = fmt.Errorf("unregister control-log failed: %v: %w", unregisterErr, err)
 		}
 	}()
-
-	err = c.RegisterEvent("control-log", func(response map[string]interface{}) {
-		logger(response)
-	})
-	if err != nil {
-		return fmt.Errorf("error registering control-log event: %w", err)
-	}
 
 	msg, err := c.Request("initiate", request)
 	if msg["success"] != "yes" {


### PR DESCRIPTION
Currently if strong-duckling fails to read an event request the event handler is
not unregistered as the methods return the request error. This can lead to a
failure state where following stat collections try to register an event handler
but fails as it is already registered as it was not unregistered before.
Strong-duckling is unable to recover from this state.

This change moves unregistration of event handlers into a defered function to
ensure that if registration succeeds we will always attempt to unregister.

RegisterEvent guarantees that it does not keep the handler registered in memory
if any part of the vici registration process fails, which gives us the guarantee
that we will never get into the mentioned bad state again.

Signed-off-by: Bjørn Sørensen <bso@lunar.app>